### PR TITLE
Time Zone setting change now only needed in ESP32TimeServerKeySettings.h file

### DIFF
--- a/Arduino/ESP32TimeServer/ESP32TimeServer.ino
+++ b/Arduino/ESP32TimeServer/ESP32TimeServer.ino
@@ -128,7 +128,7 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
 {
 
   // adjust utc time to local time
-  time_t now_Local_Time = usEastern.toLocal(UTC_Time, &tcr);
+  time_t now_Local_Time = myTZ.toLocal(UTC_Time, &tcr);
 
   // format dateLine
 

--- a/Arduino/ESP32TimeServer/ESP32TimeServerKeySettings.h
+++ b/Arduino/ESP32TimeServer/ESP32TimeServerKeySettings.h
@@ -26,6 +26,6 @@ bool debugIsOn = false;                           // set to true to see progress
 
 // Time zone                                      // Time is displayed on the LCD display in keeping with your local time zone                                             
                                                   // please see https://github.com/khoih-prog/Timezone_Generic#timechangerules-struct for more information
-TimeChangeRule usEDT = {"EDT", Second, Sun, Mar, 2, -240};  
-TimeChangeRule usEST = {"EST", First, Sun, Nov, 2, -300};   
-Timezone usEastern(usEDT, usEST);  
+TimeChangeRule myDST = {"EDT", Second, Sun, Mar, 2, -240};  
+TimeChangeRule mySTD = {"EST", First, Sun, Nov, 2, -300};   
+Timezone myTZ(myDST, mySTD);  

--- a/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
+++ b/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
@@ -128,7 +128,7 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
 {
 
   // adjust utc time to local time
-  time_t now_Local_Time = usEastern.toLocal(UTC_Time, &tcr);
+  time_t now_Local_Time = myTZ.toLocal(UTC_Time, &tcr);
 
   // format dateLine
 

--- a/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServerKeySettings.h
+++ b/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServerKeySettings.h
@@ -26,6 +26,6 @@ bool debugIsOn = false;                           // set to true to see progress
 
 // Time zone                                      // Time is displayed on the LCD display in keeping with your local time zone                                             
                                                   // please see https://github.com/khoih-prog/Timezone_Generic#timechangerules-struct for more information
-TimeChangeRule usEDT = {"EDT", Second, Sun, Mar, 2, -240};  
-TimeChangeRule usEST = {"EST", First, Sun, Nov, 2, -300};   
-Timezone usEastern(usEDT, usEST);  
+TimeChangeRule myDST = {"EDT", Second, Sun, Mar, 2, -240};  
+TimeChangeRule mySTD = {"EST", First, Sun, Nov, 2, -300};   
+Timezone myTZ(myDST, mySTD);  


### PR DESCRIPTION
With this change, you now only need to define your Time Zone settings in the ESP32TimeServerKeySettings.h file and no longer also need to modify ESP32TimeServer.ino and/or ESP32TimeServer.cpp.