### PR TITLE
Add the current time zone to the clock display

### DIFF
--- a/Arduino/ESP32TimeServer/ESP32TimeServer.ino
+++ b/Arduino/ESP32TimeServer/ESP32TimeServer.ino
@@ -171,7 +171,8 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
   else
     timeString.concat(" PM ");
   
-  timeString.concat(tcr -> abbrev);
+  if (displayTimeZone == true)
+    timeString.concat(tcr -> abbrev);
 };
 
 String GetUpTime()

--- a/Arduino/ESP32TimeServer/ESP32TimeServer.ino
+++ b/Arduino/ESP32TimeServer/ESP32TimeServer.ino
@@ -171,7 +171,7 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
   else
     timeString.concat(" PM ");
   
-  if (displayTimeZone == true)
+  if (displayTimeZone)
     timeString.concat(tcr -> abbrev);
 };
 

--- a/Arduino/ESP32TimeServer/ESP32TimeServer.ino
+++ b/Arduino/ESP32TimeServer/ESP32TimeServer.ino
@@ -167,9 +167,11 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
   timeString.concat(String(second(now_Local_Time)));
 
   if (isAM(now_Local_Time))
-    timeString.concat(" AM");
+    timeString.concat(" AM ");
   else
-    timeString.concat(" PM");
+    timeString.concat(" PM ");
+  
+  timeString.concat(tcr -> abbrev);
 };
 
 String GetUpTime()

--- a/Arduino/ESP32TimeServer/ESP32TimeServerKeySettings.h
+++ b/Arduino/ESP32TimeServer/ESP32TimeServerKeySettings.h
@@ -15,6 +15,7 @@ const uint32_t GPSBaud = 38400;                   // desired GPS baud
 const int lcdI2CAddress = 0x27;                   // lcd I2C address; if you don't know your display address, run an I2C scanner sketch
 const int lcdColumns = 20;                        // number of columns on your LCD display (typically 16 or 20)
 const int lcdRows = 4;                            // number of rows on your LCD display (typically 2 or 4)
+const bool displayTimeZone = false;               // set to true to display the time zone, set to false to not display the time zone
 
 // Button                                         // the button is used to show up time
 const int UpTimePin = 34;                         // pin on the ESP32 board which the uptime button is connected

--- a/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
+++ b/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
@@ -171,7 +171,8 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
   else
     timeString.concat(" PM ");
   
-  timeString.concat(tcr -> abbrev);
+  if (displayTimeZone == true)
+    timeString.concat(tcr -> abbrev);
 };
 
 String GetUpTime()

--- a/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
+++ b/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
@@ -171,7 +171,7 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
   else
     timeString.concat(" PM ");
   
-  if (displayTimeZone == true)
+  if (displayTimeZone)
     timeString.concat(tcr -> abbrev);
 };
 

--- a/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
+++ b/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServer.cpp
@@ -167,9 +167,11 @@ void GetAdjustedDateAndTimeStrings(time_t UTC_Time, String &dateString, String &
   timeString.concat(String(second(now_Local_Time)));
 
   if (isAM(now_Local_Time))
-    timeString.concat(" AM");
+    timeString.concat(" AM ");
   else
-    timeString.concat(" PM");
+    timeString.concat(" PM ");
+  
+  timeString.concat(tcr -> abbrev);
 };
 
 String GetUpTime()

--- a/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServerKeySettings.h
+++ b/PlatformIO/Projects/esp32TimeServer/src/ESP32TimeServerKeySettings.h
@@ -15,6 +15,7 @@ const uint32_t GPSBaud = 38400;                   // desired GPS baud
 const int lcdI2CAddress = 0x27;                   // lcd I2C address; if you don't know your display address, run an I2C scanner sketch
 const int lcdColumns = 20;                        // number of columns on your LCD display (typically 16 or 20)
 const int lcdRows = 4;                            // number of rows on your LCD display (typically 2 or 4)
+const bool displayTimeZone = false;               // set to true to display the time zone, set to false to not display the time zone
 
 // Button                                         // the button is used to show up time
 const int UpTimePin = 34;                         // pin on the ESP32 board which the uptime button is connected


### PR DESCRIPTION
This change adds the abbreviated text of the current time zone (e.g. EST, EDT etc.) to the clock display.